### PR TITLE
Add random stock API in Flask app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
 # retro-trader
+
+A minimal Flask application with a React front-end.
+
+## API Endpoints
+
+- `/api/data` - Returns a simple message.
+- `/api/random-stock` - Fetches a random stock's latest closing price along with previous closing prices using [yfinance](https://github.com/ranaroussi/yfinance).

--- a/app.py
+++ b/app.py
@@ -1,14 +1,25 @@
-# import flask
-from flask import Flask, jsonify, request
+from flask import Flask, jsonify
 from flask_cors import CORS
+
+from stock_service import get_random_stock_data
 
 app = Flask(__name__)
 CORS(app)
 
+
 @app.route("/api/data", methods=["GET"])
 def get_data():
-    # Simulated data retrieval
+    """Example endpoint returning a simple message."""
     data = {"message": "Hello, World!"}
+    return jsonify(data)
+
+
+@app.route("/api/random-stock", methods=["GET"])
+def random_stock():
+    """Return a random stock's recent closing prices."""
+    data = get_random_stock_data()
+    if not data:
+        return jsonify({"error": "No data found"}), 404
     return jsonify(data)
 
 

--- a/stock_service.py
+++ b/stock_service.py
@@ -1,0 +1,53 @@
+import random
+from datetime import datetime
+from typing import List, Dict, Any
+
+import yfinance as yf
+
+# List of potential stock symbols to choose from
+DEFAULT_SYMBOLS: List[str] = [
+    "AAPL",
+    "MSFT",
+    "GOOGL",
+    "AMZN",
+    "META",
+    "TSLA",
+    "NFLX",
+    "NVDA",
+    "INTC",
+    "IBM",
+]
+
+
+def get_random_stock_data(days: int = 5) -> Dict[str, Any]:
+    """Fetch recent historical data for a random stock symbol.
+
+    Parameters
+    ----------
+    days: int
+        Number of days of history to return (including most recent day).
+    """
+    symbol = random.choice(DEFAULT_SYMBOLS)
+    ticker = yf.Ticker(symbol)
+    history = ticker.history(period=f"{days}d")
+    history = history.reset_index()
+    if history.empty:
+        return {}
+    last_row = history.iloc[-1]
+    closing_price = float(last_row["Close"])
+    date_str = last_row["Date"].strftime("%Y-%m-%d")
+
+    previous_prices = [
+        {
+            "date": row["Date"].strftime("%Y-%m-%d"),
+            "close": float(row["Close"]),
+        }
+        for _, row in history.iloc[:-1].iterrows()
+    ]
+
+    return {
+        "symbol": symbol,
+        "date": date_str,
+        "close": closing_price,
+        "previous_closes": previous_prices,
+    }


### PR DESCRIPTION
## Summary
- implement `get_random_stock_data` in new `stock_service.py`
- add `/api/random-stock` endpoint to Flask app
- document new endpoint in README

## Testing
- `python -m py_compile app.py stock_service.py`
- `black app.py stock_service.py`
- *(failed to fetch stock data during manual test due to blocked network)*

------
https://chatgpt.com/codex/tasks/task_e_688d54df71c4832aaa41aa731f8a4c8b