### PR TITLE
Add profit calculation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ A minimal Flask application with a React front-end.
 
 - `/api/data` - Returns a simple message.
 - `/api/random-stock` - Fetches a random stock's latest closing price along with previous closing prices using [yfinance](https://github.com/ranaroussi/yfinance).
+- `/api/calc` - Calculates profit or loss for a stock position based on ticker, purchase date, and share count.

--- a/app.py
+++ b/app.py
@@ -1,7 +1,7 @@
-from flask import Flask, jsonify
+from flask import Flask, jsonify, request
 from flask_cors import CORS
 
-from stock_service import get_random_stock_data
+from stock_service import get_random_stock_data, calculate_profit
 
 app = Flask(__name__)
 app.url_map.strict_slashes = False
@@ -22,6 +22,27 @@ def random_stock():
     if not data:
         return jsonify({"error": "No data found"}), 404
     return jsonify(data)
+
+
+@app.route("/api/calc", methods=["POST"])
+def calc_profit():
+    """Calculate profit or loss for a given stock position."""
+    payload = request.get_json(force=True, silent=True) or {}
+    ticker = payload.get("ticker")
+    purchase_date = payload.get("purchase_date")
+    shares = payload.get("shares")
+
+    try:
+        shares = float(shares)
+        if shares <= 0:
+            raise ValueError
+    except (TypeError, ValueError):
+        return jsonify({"error": "Shares must be a positive number"}), 400
+
+    profit = calculate_profit(ticker, purchase_date, shares)
+    if profit is None:
+        return jsonify({"error": "Price data unavailable"}), 400
+    return jsonify({"profit": profit})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- calculate profit or loss for a stock purchase
- expose new `/api/calc` endpoint
- document new endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d5c804f08832aa6280bfa663f5902