### PR TITLE
Refactor Flask code into package

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,18 @@
 
 A minimal Flask application with a React front-end.
 
+Run the API with:
+
+```
+python -m retrotrader
+```
+
+or using Flask's CLI:
+
+```
+flask --app retrotrader run
+```
+
 ## API Endpoints
 
 - `/api/data` - Returns a simple message.

--- a/retrotrader/__init__.py
+++ b/retrotrader/__init__.py
@@ -1,0 +1,9 @@
+from flask import Flask
+from flask_cors import CORS
+
+app = Flask(__name__)
+app.url_map.strict_slashes = False
+CORS(app)
+
+# Register routes
+from . import routes  # noqa: E402,F401

--- a/retrotrader/__main__.py
+++ b/retrotrader/__main__.py
@@ -1,4 +1,4 @@
-from retrotrader import app
+from . import app
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/retrotrader/routes.py
+++ b/retrotrader/routes.py
@@ -1,0 +1,40 @@
+from flask import jsonify, request
+
+from . import app
+from .yfinance_utils import get_random_stock_data, calculate_profit
+
+
+@app.route("/api/data", methods=["GET"])
+def get_data():
+    """Example endpoint returning a simple message."""
+    return jsonify({"message": "Hello, World!"})
+
+
+@app.route("/api/random-stock", methods=["GET"])
+def random_stock():
+    """Return a random stock's recent closing prices."""
+    data = get_random_stock_data()
+    if not data:
+        return jsonify({"error": "No data found"}), 404
+    return jsonify(data)
+
+
+@app.route("/api/calc", methods=["POST"])
+def calc_profit():
+    """Calculate profit or loss for a given stock position."""
+    payload = request.get_json(force=True, silent=True) or {}
+    ticker = payload.get("ticker")
+    purchase_date = payload.get("purchase_date")
+    shares = payload.get("shares")
+
+    try:
+        shares = float(shares)
+        if shares <= 0:
+            raise ValueError
+    except (TypeError, ValueError):
+        return jsonify({"error": "Shares must be a positive number"}), 400
+
+    profit = calculate_profit(ticker, purchase_date, shares)
+    if profit is None:
+        return jsonify({"error": "Price data unavailable"}), 400
+    return jsonify({"profit": profit})

--- a/retrotrader/yfinance_utils.py
+++ b/retrotrader/yfinance_utils.py
@@ -20,13 +20,7 @@ DEFAULT_SYMBOLS: List[str] = [
 
 
 def get_random_stock_data(days: int = 5) -> Dict[str, Any]:
-    """Fetch recent historical data for a random stock symbol.
-
-    Parameters
-    ----------
-    days: int
-        Number of days of history to return (including most recent day).
-    """
+    """Fetch recent historical data for a random stock symbol."""
     symbol = random.choice(DEFAULT_SYMBOLS)
     ticker = yf.Ticker(symbol)
     history = ticker.history(period=f"{days}d")
@@ -53,26 +47,8 @@ def get_random_stock_data(days: int = 5) -> Dict[str, Any]:
     }
 
 
-def calculate_profit(
-    ticker: str, purchase_date: str, shares: float
-) -> Optional[float]:
-    """Calculate profit for a given ticker and share count.
-
-    Parameters
-    ----------
-    ticker: str
-        Stock ticker symbol.
-    purchase_date: str
-        Date shares were purchased in ``YYYY-MM-DD`` format.
-    shares: float
-        Number of shares purchased.
-
-    Returns
-    -------
-    Optional[float]
-        Profit or loss. ``None`` if price data is unavailable.
-    """
-
+def calculate_profit(ticker: str, purchase_date: str, shares: float) -> Optional[float]:
+    """Calculate profit or loss for a given stock position."""
     try:
         datetime.strptime(purchase_date, "%Y-%m-%d")
     except ValueError:


### PR DESCRIPTION
## Summary
- reorganize files into a `retrotrader` Python package
- move Flask initialization to `retrotrader/__init__.py`
- put API routes in `retrotrader/routes.py`
- add `yfinance_utils.py` with stock helper functions
- keep `app.py` as thin runner and update README instructions

## Testing
- `python -m retrotrader -h`
- `flask --app retrotrader routes`
- `python app.py -h`


------
https://chatgpt.com/codex/tasks/task_e_688d60756ad0832aac20469910c5e148