### PR TITLE
Integrate stock context into chart components

### DIFF
--- a/client/src/Home.tsx
+++ b/client/src/Home.tsx
@@ -1,44 +1,13 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useStock } from '@/contexts/useStock';
 
-interface StockData {
-  symbol: string;
-  date: string;
-  close: number;
-  previous_closes: { date: string; close: number }[];
-}
-
 const Home = () => {
-  const [stock, setStock] = useState<StockData | null>(null); // Initialize stock as null
-  const [loading, setLoading] = useState(true); // Track loading state
-  const [error, setError] = useState<string | null>(null); // Track error state
+  const { stock, loading, error } = useStock();
 
   const [shares, setShares] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [profit, setProfit] = useState<number | null>(null);
   const [calcError, setCalcError] = useState<string | null>(null);
-
-  useEffect(() => {
-    fetch('/api/random-stock')
-      .then((res) => {
-        if (!res.ok) {
-          throw new Error(`HTTP ${res.status}: Failed to fetch stock data`);
-        }
-        return res.json();
-      })
-      .then((data) => {
-        if (!data.symbol || !data.date || typeof data.close !== 'number') {
-          throw new Error('Invalid stock data format');
-        }
-        setStock(data);
-        setLoading(false);
-      })
-      .catch((err: Error) => {
-        console.error('Fetch error:', err);
-        setError(err.message);
-        setLoading(false);
-      });
-  }, []);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -70,14 +39,6 @@ const Home = () => {
       setSubmitting(false);
     }
   };
-
-  if (loading) {
-    return <p>Loading...</p>;
-  }
-
-  if (error || !stock) {
-    return <p>Error: {error || 'Unable to load stock data'}</p>;
-  }
 
   if (loading) {
     return <p>Loading...</p>;

--- a/client/src/components/chart/chartLineLabel.tsx
+++ b/client/src/components/chart/chartLineLabel.tsx
@@ -19,32 +19,33 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 
-const chartData = [
-  { month: 'January', desktop: 186, mobile: 80 },
-  { month: 'February', desktop: 305, mobile: 200 },
-  { month: 'March', desktop: 237, mobile: 120 },
-  { month: 'April', desktop: 73, mobile: 190 },
-  { month: 'May', desktop: 209, mobile: 130 },
-  { month: 'June', desktop: 214, mobile: 140 },
-];
-
-const chartConfig = {
-  desktop: {
-    label: 'Desktop',
-    color: 'var(--chart-1)',
-  },
-  mobile: {
-    label: 'Mobile',
-    color: 'var(--chart-2)',
-  },
-} satisfies ChartConfig;
-
 export const ChartLineLabel = () => {
+  const { stock, loading, error } = useStock();
+
+  if (loading) {
+    return <p>Loading...</p>;
+  }
+
+  if (error || !stock) {
+    return <p>Error loading chart</p>;
+  }
+
+  const chartData = [...stock.previous_closes, { date: stock.date, close: stock.close }];
+
+  const chartConfig = {
+    close: {
+      label: `${stock.symbol} Close`,
+      color: 'var(--chart-1)',
+    },
+  } satisfies ChartConfig;
+
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Line Chart - Label</CardTitle>
-        <CardDescription>January - June 2024</CardDescription>
+        <CardTitle>{stock.symbol} Closing Prices</CardTitle>
+        <CardDescription>
+          {chartData[0].date} - {chartData[chartData.length - 1].date}
+        </CardDescription>
       </CardHeader>
       <CardContent>
         <ChartContainer config={chartConfig}>
@@ -59,23 +60,22 @@ export const ChartLineLabel = () => {
           >
             <CartesianGrid vertical={false} />
             <XAxis
-              dataKey="month"
+              dataKey="date"
               tickLine={false}
               axisLine={false}
               tickMargin={8}
-              tickFormatter={(value) => value.slice(0, 3)}
             />
             <ChartTooltip
               cursor={false}
               content={<ChartTooltipContent indicator="line" />}
             />
             <Line
-              dataKey="desktop"
+              dataKey="close"
               type="linear"
-              stroke="var(--color-desktop)"
+              stroke="var(--color-close)"
               strokeWidth={2}
               dot={{
-                fill: 'var(--color-desktop)',
+                fill: 'var(--color-close)',
               }}
               activeDot={{
                 r: 6,
@@ -93,10 +93,10 @@ export const ChartLineLabel = () => {
       </CardContent>
       <CardFooter className="flex-col items-start gap-2 text-sm">
         <div className="flex gap-2 leading-none font-medium">
-          Trending up by 5.2% this month
+          {stock.symbol} last {chartData.length} days
         </div>
         <div className="text-muted-foreground leading-none">
-          Showing total visitors for the last 6 months
+          Closing prices
         </div>
       </CardFooter>
     </Card>

--- a/client/src/contexts/StockContext.tsx
+++ b/client/src/contexts/StockContext.tsx
@@ -1,20 +1,22 @@
+/* eslint-disable react-refresh/only-export-components */
 import { createContext, useEffect, useState, type ReactNode } from 'react';
 
-interface StockData {
+export interface StockData {
   symbol: string;
   date: string;
   close: number;
   previous_closes: { date: string; close: number }[];
 }
 
-interface StockContextType {
+export interface StockContextType {
   stock: StockData | null;
   loading: boolean;
   error: string | null;
   refetchStock: () => void;
 }
 
-const StockContext = createContext<StockContextType | undefined>(undefined);
+export const StockContext = createContext<StockContextType | undefined>(undefined);
+
 export const StockProvider = ({ children }: { children: ReactNode }) => {
   const [stock, setStock] = useState<StockData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -33,9 +35,10 @@ export const StockProvider = ({ children }: { children: ReactNode }) => {
         throw new Error('Invalid stock data format');
       }
       setStock(data);
-    } catch (err: any) {
+    } catch (err) {
       console.error('Fetch error:', err);
-      setError(err.message);
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      setError(message);
     } finally {
       setLoading(false);
     }

--- a/client/src/contexts/useStock.ts
+++ b/client/src/contexts/useStock.ts
@@ -1,4 +1,5 @@
-import { useContext } from "react";
+import { useContext } from 'react';
+import { StockContext } from './StockContext';
 
 export const useStock = () => {
   const context = useContext(StockContext);


### PR DESCRIPTION
## Summary
- expose `StockContext` with provider and typed data
- consume stock context in Home and ChartLineLabel components
- show closing prices from context in line chart

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ed2124fc4832ab1fdb95eb57a30fe